### PR TITLE
tools: extract linux type definitions to local header

### DIFF
--- a/tools/include/tools/be_byteshift.h
+++ b/tools/include/tools/be_byteshift.h
@@ -1,7 +1,11 @@
 #ifndef _TOOLS_BE_BYTESHIFT_H
 #define _TOOLS_BE_BYTESHIFT_H
 
+#ifdef __linux__
 #include <linux/types.h>
+#else
+#include "linux_types.h"
+#endif
 
 static inline __u16 __get_unaligned_be16(const __u8 *p)
 {

--- a/tools/include/tools/le_byteshift.h
+++ b/tools/include/tools/le_byteshift.h
@@ -1,7 +1,11 @@
 #ifndef _TOOLS_LE_BYTESHIFT_H
 #define _TOOLS_LE_BYTESHIFT_H
 
+#ifdef __linux__
 #include <linux/types.h>
+#else
+#include "linux_types.h"
+#endif
 
 static inline __u16 __get_unaligned_le16(const __u8 *p)
 {

--- a/tools/include/tools/linux_types.h
+++ b/tools/include/tools/linux_types.h
@@ -1,0 +1,22 @@
+#ifndef __LINUX_TYPES_H
+#define __LINUX_TYPES_H
+
+#include <stdint.h>
+
+typedef uint8_t __u8;
+typedef uint8_t __be8;
+typedef uint8_t __le8;
+
+typedef uint16_t __u16;
+typedef uint16_t __be16;
+typedef uint16_t __le16;
+
+typedef uint32_t __u32;
+typedef uint32_t __be32;
+typedef uint32_t __le32;
+
+typedef uint64_t __u64;
+typedef uint64_t __be64;
+typedef uint64_t __le64;
+
+#endif


### PR DESCRIPTION
This allows for building the kernel on non-linux platforms.
The patch was taken from official OpenWrt trunk releases.

Change-Id: Idd70ca8774a0ba83eba8b80d05502155815d1e1d
